### PR TITLE
Fix spelling for your computer and windows product

### DIFF
--- a/BSODSaverView.m
+++ b/BSODSaverView.m
@@ -21,51 +21,51 @@ NSString *const kExternalURL = @"http://www.github.com/dessibelle/Blue-Screen-Sa
 {
     self = [super initWithFrame:frame isPreview:isPreview];
     if (self) {
-        
+
         ScreenSaverDefaults *defaults;
         defaults = [ScreenSaverDefaults defaultsForModuleWithName:@"BlueScreenSaver"];
-        
+
         // Register our default values
         [defaults registerDefaults:[NSDictionary dictionaryWithObjectsAndKeys:
                                     @0.5, @"CrashType",
                                     @0.5, @"Fatality",
                                     nil]];
-        
-        
+
+
 		self.backgroundColor = [NSColor colorWithCalibratedRed:(1.0/255.0) green:(2.0/255.0) blue:(172.0/255.0) alpha:1.0];
 		self.captionBackgroundColor = [NSColor colorWithCalibratedRed:(169.0/255.0) green:(170.0/255.0) blue:(174.0/255.0) alpha:1.0];
 		self.hasUnderscoreSuffix = NO;
-		
+
 		[self setAnimationTimeInterval:1/1.5];
-		
+
 		/* FixedsysTTF / LucidaConsole: File names must match post script names */
 		NSString *bundleIdentifier = [[[NSBundle bundleForClass:[self class]] infoDictionary] objectForKey:@"CFBundleIdentifier"];
 		self.defaults = [ScreenSaverDefaults defaultsForModuleWithName:bundleIdentifier];
-				
+
         NSBundle *screenSaverBundle = [NSBundle bundleWithIdentifier:bundleIdentifier];
         [self loadFontWithName:@"FixedsysTTF" inBundle:screenSaverBundle];
         [self loadFontWithName:@"LucidaConsole" inBundle:screenSaverBundle];
-		
+
 		float fontSize = isPreview ? 6.0 : 15.0;
-		
+
 		srand48(arc4random());
-        
+
         double fatal_rand = drand48() -0.5 + [defaults doubleForKey:@"Fatality"];
         double xp_rand = drand48() -0.5 + [defaults doubleForKey:@"CrashType"];
-    
+
         self.fatal = fatal_rand >= 0.5;
         self.xp = xp_rand >= 0.5;
-		
+
 		if (self.xp) {
 			self.font = [NSFont fontWithName:@"LucidaConsole" size:fontSize];
 		} else {
 			self.font = [NSFont fontWithName:@"FixedsysTTF" size:fontSize];
 		}
-		
+
 		/* 9.X : VMM / DiskTSD / voltrack  */
-		
+
 		if (self.xp) {
-		
+
 			NSInteger	addr1 = rand(),
 			addr2 = rand(),
 			addr3 = rand(),
@@ -74,20 +74,20 @@ NSString *const kExternalURL = @"http://www.github.com/dessibelle/Blue-Screen-Sa
 			addr6 = rand(),
 			addr7 = rand(),
 			addr8 = rand();
-			
-			self.contentString = [NSString stringWithFormat:@"A problem has been detected and windows has been shut down to prevent damage\nto you computer.\n\nThe problem seems to be caused by the following file: SPCMDCON.SYS\n\nPAGE_FAULT_IN_NONPAGED_AREAD\n\nIf this is the first time you've seen this stop error screen,\nrestart you computer. If this screen appears again, follow\nthese steps:\n\nCheck to make sure any new hardware or software is properly installed.\nIf this is a new installation, ask you hardware or software manufacturer\nfor any windows updates you might need.\n\nIf problems continue, disable or remove any newly installed hardware\nor software. Disable BIOS memory options such as caching or shadowing.\nIf you need to use Safe Mode to remove or disable components, restart\nyour computer, press F8 to select Advanced Startup Options, and then\nselect Safe Mode.\n\nTechnical information:\n\n*** STOP: 0x%08lX (0x%08lX, 0x%08lX, 0x%08lX, 0x%08lX)\n\n\n*** SPCMDCON.SES - Address %08lX base at %08lX, DateStamp %08lx ", addr1, addr2, addr3, addr4, addr5, addr6, addr7, addr8];
-			
+
+			self.contentString = [NSString stringWithFormat:@"A problem has been detected and Windows has been shut down to prevent damage\nto your computer.\n\nThe problem seems to be caused by the following file: SPCMDCON.SYS\n\nPAGE_FAULT_IN_NONPAGED_AREAD\n\nIf this is the first time you've seen this stop error screen,\nrestart your computer. If this screen appears again, follow\nthese steps:\n\nCheck to make sure any new hardware or software is properly installed.\nIf this is a new installation, ask you hardware or software manufacturer\nfor any Windows updates you might need.\n\nIf problems continue, disable or remove any newly installed hardware\nor software. Disable BIOS memory options such as caching or shadowing.\nIf you need to use Safe Mode to remove or disable components, restart\nyour computer, press F8 to select Advanced Startup Options, and then\nselect Safe Mode.\n\nTechnical information:\n\n*** STOP: 0x%08lX (0x%08lX, 0x%08lX, 0x%08lX, 0x%08lX)\n\n\n*** SPCMDCON.SES - Address %08lX base at %08lX, DateStamp %08lx ", addr1, addr2, addr3, addr4, addr5, addr6, addr7, addr8];
+
 		} else if (self.fatal) {
-			
+
 			NSInteger	addr1 = rand() % (0xFFFF - 0x1000) + 0x1000,
 			addr2 = rand(),
 			addr3 = rand(),
 			exception = rand() % (0x0F - 0x01) + 0x01;
-			
-			self.contentString = [NSString stringWithFormat:@"A fatal exception %02lX has occured at %04lX:%08lX in VxD VMM(01) + \n%08lX. The current application will be terminated.\n\n* Press any key to terminate the current application.\n* Press CTRL+ALT+RESET to restart you computer. You will\n  lose any unsaved information in all applications.\n\n\n		             Press any key to continue ", exception, addr1, addr2, addr3];
-			
+
+			self.contentString = [NSString stringWithFormat:@"A fatal exception %02lX has occured at %04lX:%08lX in VxD VMM(01) + \n%08lX. The current application will be terminated.\n\n* Press any key to terminate the current application.\n* Press CTRL+ALT+RESET to restart your computer. You will\n  lose any unsaved information in all applications.\n\n\n		             Press any key to continue ", exception, addr1, addr2, addr3];
+
 		} else {
-			
+
 			NSInteger	addr1 = rand() % (0xFFFF - 0x1000) + 0x1000,
 			addr2 = rand(),
 			addr3 = rand(),
@@ -95,29 +95,29 @@ NSString *const kExternalURL = @"http://www.github.com/dessibelle/Blue-Screen-Sa
 			addr5 = rand(),
 			addr6 = rand(),
 			exception = rand() % (0x0F - 0x01) + 0x01;
-			
-			self.contentString = [NSString stringWithFormat:@"An exception %02lX has occured at %04lX:%08lX in VxD VMM(01) + \n%08lX. This was called from %04lX:%08lX in VxD VMM(01) + \n%08lX. It may be possible to continue normally.\n\n* Press any key to terminate the current application.\n* Press CTRL+ALT+RESET to restart you computer. You will\n  lose any unsaved information in all applications.\n\n\n		             Press any key to continue ", exception, addr1, addr2, addr3, addr4, addr5, addr6];
+
+			self.contentString = [NSString stringWithFormat:@"An exception %02lX has occured at %04lX:%08lX in VxD VMM(01) + \n%08lX. This was called from %04lX:%08lX in VxD VMM(01) + \n%08lX. It may be possible to continue normally.\n\n* Press any key to terminate the current application.\n* Press CTRL+ALT+RESET to restart your computer. You will\n  lose any unsaved information in all applications.\n\n\n		             Press any key to continue ", exception, addr1, addr2, addr3, addr4, addr5, addr6];
 		}
-		
+
 		self.captionString = @" Windows ";
-		
+
 		self.drawingAttributes = [NSDictionary dictionaryWithObjectsAndKeys:self.font, NSFontAttributeName,
 								   [NSColor whiteColor], NSForegroundColorAttributeName,
 								   nil];
-		
+
 		self.captionDrawingAttributes = [NSDictionary dictionaryWithObjectsAndKeys:self.font, NSFontAttributeName,
 										 self.backgroundColor, NSForegroundColorAttributeName,
 										 self.captionBackgroundColor, NSBackgroundColorAttributeName,
 										 nil];
     }
-	
+
     return self;
 }
 
 - (void)animateOneFrame
 {
 	self.hasUnderscoreSuffix = !self.hasUnderscoreSuffix;
-    
+
     [self setNeedsDisplay:YES];
 }
 
@@ -125,34 +125,34 @@ NSString *const kExternalURL = @"http://www.github.com/dessibelle/Blue-Screen-Sa
 {
 	if (![self isPreview])
 		[[NSGraphicsContext currentContext] setShouldAntialias:NO];
-	
+
 	[self.backgroundColor set];
 	[self.font set];
-	
+
 	/*
 	 *  ▋ █ ▊
 	 */
-	
+
 	NSString *message = [self.contentString stringByAppendingString:(self.hasUnderscoreSuffix ? @"_" : @"▋")];
-	
+
 	NSRectFill(rect);
-	
+
 	NSSize captionSize = [self.captionString sizeWithAttributes:self.captionDrawingAttributes];
 	NSSize contentSize = [message sizeWithAttributes:self.drawingAttributes];
-	
+
 	NSRect captionRect = NSMakeRect((rect.size.width - captionSize.width) / 2.0,
-									((rect.size.height + contentSize.height) / 2.0) + (self.xp ? 0 : captionSize.height), 
+									((rect.size.height + contentSize.height) / 2.0) + (self.xp ? 0 : captionSize.height),
 									captionSize.width,
 									captionSize.height);
 
 	NSRect contentRect = NSMakeRect((rect.size.width - contentSize.width) / 2.0,
-									((rect.size.height - contentSize.height) / 2.0) - (self.xp ? 0 : captionSize.height), 
+									((rect.size.height - contentSize.height) / 2.0) - (self.xp ? 0 : captionSize.height),
 									contentSize.width,
 									contentSize.height);
-	
+
 	if (!self.xp)
 		[self.captionString drawInRect:captionRect withAttributes:self.captionDrawingAttributes];
-	
+
 	[message drawInRect:contentRect withAttributes:self.drawingAttributes];
 }
 
@@ -169,22 +169,22 @@ NSString *const kExternalURL = @"http://www.github.com/dessibelle/Blue-Screen-Sa
 - (NSWindow *)configureSheet
 {
     ScreenSaverDefaults *defaults = [ScreenSaverDefaults defaultsForModuleWithName:@"BlueScreenSaver"];
-    
+
     if (!self.configSheet)
     {
         NSArray *topLevelObjects;
-        
+
         if (![[NSBundle bundleForClass:[self class]] loadNibNamed:@"ConfigureSheet" owner:self topLevelObjects:&topLevelObjects])
         {
             NSLog( @"Failed to load configure sheet." );
             NSBeep();
         }
     }
-    
-    
+
+
     [self.fatalitySlider setFloatValue:[defaults floatForKey:@"Fatality"]];
     [self.typeSlider setFloatValue:[defaults floatForKey:@"CrashType"]];
-    
+
     return self.configSheet;
 
 }
@@ -224,9 +224,9 @@ NSString *const kExternalURL = @"http://www.github.com/dessibelle/Blue-Screen-Sa
 
     [defaults setFloat:self.fatalitySlider.floatValue forKey:@"Fatality"];
     [defaults setFloat:self.typeSlider.floatValue forKey:@"CrashType"];
-    
+
     [defaults synchronize];
-    
+
     [self configSheetCancelAction:sender];
 }
 

--- a/XP.txt
+++ b/XP.txt
@@ -1,17 +1,17 @@
-A problem has been detected and windows has been shut down to prevent damage
-to you computer.
+A problem has been detected and Windows has been shut down to prevent damage
+to your computer.
 
 The problem seems to be caused by the following file: SPCMDCON.SYS
 
 PAGE_FAULT_IN_NONPAGED_AREAD
 
 If this is the first time you've seen this stop error screen,
-restart you computer. If this screen appears again, follow
+restart your computer. If this screen appears again, follow
 these steps:
 
 Check to make sure any new hardware or software is properly installed.
 If this is a new installation, ask you hardware or software manufacturer
-for any windows updates you might need.
+for any Windows updates you might need.
 
 If problems continue, disable or remove any newly installed hardware
 or software. Disable BIOS memory options such as caching or shadowing.

--- a/blue.rtf
+++ b/blue.rtf
@@ -4,40 +4,40 @@
 \paperw11900\paperh16840\margl1440\margr1440\vieww9000\viewh8400\viewkind0
 \pard\tx566\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\ql\qnatural\pardirnatural
 
-\f0\fs24 \cf0 An exception 
+\f0\fs24 \cf0 An exception
 \f1\b 06 has occured at 0028:C11B3ADC
 \f0\b0  in VxD
 \f1\b  DiskTSD(03)
-\f0\b0  + 
+\f0\b0  +
 \f1\b 00001660
-\f0\b0 . This was called from 
+\f0\b0 . This was called from
 \f1\b 0028:C11B40C8
 \f0\b0  in VxD
 \f1\b  voltrack(04)
-\f0\b0  + 
+\f0\b0  +
 \f1\b 00000000
 \f0\b0 . It may be possible to continue normally.\
 \
 * Press any key to attempt to continue.\
-* Press CTRL+ALT+RESET to restart you computer. You will lose any unsaved information in all applications.\
+* Press CTRL+ALT+RESET to restart your computer. You will lose any unsaved information in all applications.\
 \
 Press any key to continue\
 \
 -\
 \
-A fatal exception 
+A fatal exception
 \f1\b 0E
-\f0\b0  has occured at 
+\f0\b0  has occured at
 \f1\b 0020:C0011E36
-\f0\b0  in VxD 
+\f0\b0  in VxD
 \f1\b VMM(01)
-\f0\b0  + 
+\f0\b0  +
 \f1\b 0001BE36
 \f0\b0 . The current application will be terminated.\
 \
 \pard\tx566\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\ql\qnatural\pardirnatural
 \cf0 * Press any key to terminate the current application.\
-* Press CTRL+ALT+RESET to restart you computer. You will lose any unsaved information in all applications.\
+* Press CTRL+ALT+RESET to restart your computer. You will lose any unsaved information in all applications.\
 \
 Press any key to continue\
 }


### PR DESCRIPTION
Several of the screensavers said `you computer` instead of `your computer`.

Also windows was in lowercase. The product name should always be capitalized. Looks more authentic.